### PR TITLE
fix: enforce plain Last updated label in README snapshot

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -11,6 +11,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+
 jobs:
   ping_and_notify:
     runs-on: ubuntu-latest
@@ -22,12 +25,12 @@ jobs:
         id: send_request
         run: |
           API_URL="https://anc.ca.apm.activecommunities.com/ottawa/rest/activities/list?locale=en-US"
-          
+
           # Dynamically get today's date
           TODAY=$(date +"%Y-%m-%d")
-          
+
           # Use a heredoc to safely store the complex JSON payload
-          POST_DATA=$(cat <<EOF
+          POST_DATA=$(cat <<EOF_POST
           {
             "activity_search_pattern": {
               "skills": [],
@@ -58,12 +61,12 @@ jobs:
             },
             "activity_transfer_pattern": {}
           }
-          EOF
+          EOF_POST
           )
-          
+
           # Send request: Output body to api_response.json and capture only the HTTP status code
           HTTP_STATUS=$(curl -s -o api_response.json -w "%{http_code}" -X POST -H "Content-Type: application/json" -d "$POST_DATA" "$API_URL")
-          
+
           # Save ONLY the HTTP Status to environment variables
           echo "HTTP_STATUS=$HTTP_STATUS" >> "$GITHUB_ENV"
 
@@ -80,7 +83,7 @@ jobs:
           # 2. Calculate statistics strictly and safely
           TOTAL_CLASSES=$(jq -r '.body.activity_items // [] | length' api_response.json)
           OPEN_CLASSES=$(jq -r '[.body.activity_items // [] | .[] | select((.total_open // 0) > (.already_enrolled // 0))] | length' api_response.json)
-          
+
           TOTAL_CLASSES=${TOTAL_CLASSES:-0}
           OPEN_CLASSES=${OPEN_CLASSES:-0}
           FULL_CLASSES=$((TOTAL_CLASSES - OPEN_CLASSES))
@@ -93,7 +96,7 @@ jobs:
           echo "Classes Full          : $FULL_CLASSES"
           echo "Classes with Openings : $OPEN_CLASSES"
           echo "-----------------------------------"
-          
+
           if [ "$OPEN_CLASSES" -eq 0 ] && [ "$TOTAL_CLASSES" -gt 0 ]; then
             echo "All classes are currently full."
           elif [ "$TOTAL_CLASSES" -eq 0 ]; then
@@ -102,11 +105,66 @@ jobs:
             jq . api_response.json || cat api_response.json
             echo "--------------------------------------"
           fi
-          
+
           # Output variables for next steps
           echo "total_classes=$TOTAL_CLASSES" >> "$GITHUB_OUTPUT"
           echo "full_classes=$FULL_CLASSES" >> "$GITHUB_OUTPUT"
           echo "open_classes=$OPEN_CLASSES" >> "$GITHUB_OUTPUT"
+
+      - name: Update README with latest status
+        run: |
+          UPDATED_AT=$(date -u +"%Y-%m-%d %H:%M UTC")
+          LAST_UPDATED_LABEL="Last updated"
+
+          if [ "${{ steps.parse_response.outputs.open_classes }}" -gt 0 ]; then
+            AVAILABILITY_STATUS="🟢 Open spots available"
+          elif [ "${{ steps.parse_response.outputs.total_classes }}" -gt 0 ]; then
+            AVAILABILITY_STATUS="🟡 No open spots (all classes full)"
+          else
+            AVAILABILITY_STATUS="🔴 No matching classes found"
+          fi
+
+          awk \
+            -v updated_at="$UPDATED_AT" \
+            -v http_status="$HTTP_STATUS" \
+            -v total_classes="${{ steps.parse_response.outputs.total_classes }}" \
+            -v full_classes="${{ steps.parse_response.outputs.full_classes }}" \
+            -v open_classes="${{ steps.parse_response.outputs.open_classes }}" \
+            -v availability_status="$AVAILABILITY_STATUS" \
+            -v last_updated_label="$LAST_UPDATED_LABEL" '
+            /<!-- availability:start -->/ {
+              print "<!-- availability:start -->"
+              # Keep plain text (no markdown italics/underscores) for last-updated line.
+              print last_updated_label ": " updated_at
+              print ""
+              print "- HTTP Status: " http_status
+              print "- Total classes: " total_classes
+              print "- Full classes: " full_classes
+              print "- Classes with openings: " open_classes
+              print "- Status: " availability_status
+              print "<!-- availability:end -->"
+              skip=1
+              next
+            }
+            /<!-- availability:end -->/ {
+              skip=0
+              next
+            }
+            !skip { print }
+          ' README.md > README.tmp && mv README.tmp README.md
+
+      - name: Commit README updates
+        run: |
+          if git diff --quiet README.md; then
+            echo "No README changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore: update swim availability snapshot"
+          git push
 
       - name: Send Dry Run Statistics (Manual Trigger)
         if: inputs.dry_run == true
@@ -134,10 +192,10 @@ jobs:
             DATES=$(echo "$i" | jq -r '.date_range')
             TIME=$(echo "$i" | jq -r '.time_range')
             DETAIL_URL=$(echo "$i" | jq -r '.detail_url')
-            
+
             # Calculate exactly how many spots are left
             SPOTS_LEFT=$(echo "$i" | jq -r '(.total_open // 0) - (.already_enrolled // 0)')
-            
+
             # Message formatted for WhatsApp readability
             MESSAGE=$(printf "🚨 *OPENING FOUND!*\n*Class:* %s\n*Days:* %s\n*Dates:* %s\n*Time:* %s\n*Spots Available:* %s\n*Link:* %s" \
               "$NAME" "$DOW" "$DATES" "$TIME" "$SPOTS_LEFT" "$DETAIL_URL")

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # swimming-watcher-winter-2025
+
+![GitHub Actions Workflow Status](../../actions/workflows/notifier.yml/badge.svg)
+
+Tracks hourly availability for **Swim Colours 5 – Purple (low ratio)** and sends WhatsApp alerts when openings appear.
+
+## Current Availability Snapshot
+<!-- availability:start -->
+Last updated: Never
+
+- HTTP Status: Unknown
+- Total classes: Unknown
+- Full classes: Unknown
+- Classes with openings: Unknown
+- Status: Unknown
+<!-- availability:end -->
+
+## Development workflow
+- Always sync from the latest `main` before making changes (`git checkout main && git pull`).


### PR DESCRIPTION
### Motivation
- Prevent the README snapshot generator from emitting markdown-italicized text by ensuring the "Last updated" line is always plain text and not wrapped with underscores. 
- Make the workflow robust and explicit about the label used when writing the availability snapshot into `README.md`.
- Ensure the workflow has the necessary permissions and tidier heredoc handling for the API request payload.

### Description
- Add a `LAST_UPDATED_LABEL="Last updated"` variable and pass it into the `awk` renderer so the README shows `Last updated: <timestamp>` as plain text. 
- Update the `awk` template to use `print last_updated_label ": " updated_at` and add an inline comment explaining why underscores/italics are avoided. 
- Add `permissions: contents: write` and tidy small formatting issues in `.github/workflows/notifier.yml` including renaming the heredoc token to `EOF_POST`. 
- Update `README.md` snapshot block and add a short development workflow note reminding contributors to sync from `main` before edits.

### Testing
- Ran `git checkout main && git pull --ff-only` and observed no upstream remote configured for `main` in this environment. 
- Ran `git diff --check` and it returned no issues. 
- Reviewed the workflow diff with `git diff -- .github/workflows/notifier.yml` and inspected the updated `awk` block to confirm the `Last updated` label is emitted as plain text.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2c616a80832fbbca56ee649e6bbf)