### PR TITLE
fix: correctly render last updated timestamp in README snapshot

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -125,7 +125,7 @@ jobs:
 
           AVAILABILITY_BLOCK=$(cat <<EOF_BLOCK
           <!-- availability:start -->
-          _Last updated: $UPDATED_AT_
+          _Last updated: ${UPDATED_AT}_
 
           - HTTP Status: $HTTP_STATUS
           - Total classes: ${{ steps.parse_response.outputs.total_classes }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tracks hourly availability for **Swim Colours 5 – Purple (low ratio)** and sen
 
 ## Current Availability Snapshot
 <!-- availability:start -->
-_Last updated: 
+_Last updated: Not yet generated_
 
 - HTTP Status: 200
 - Total classes: 8


### PR DESCRIPTION
### Motivation
- The GitHub Actions README update block used a literal `_$UPDATED_AT_` which prevented the `UPDATED_AT` timestamp from being interpolated in the generated availability snapshot, and the README did not show a friendly placeholder before the first workflow run.

### Description
- Replace the literal timestamp token with `${UPDATED_AT}` in `.github/workflows/notifier.yml` and update the README placeholder line to `_Last updated: Not yet generated_` so the availability block renders correctly before and after the workflow updates it.

### Testing
- Ran `rg -n '\$UPDATED_AT_' .github/workflows/notifier.yml README.md` to confirm no remaining `\$UPDATED_AT_` references (no matches), and attempted `python -c 'import yaml; yaml.safe_load(open(".github/workflows/notifier.yml"))'` which failed because `PyYAML` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b32af2460832f873fc8024663364e)