### PR TITLE
feat(actions): create/close swim opening issues and assign KingBain

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   ping_and_notify:
@@ -143,6 +144,58 @@ jobs:
           echo "total_classes=$TOTAL_CLASSES" >> "$GITHUB_OUTPUT"
           echo "full_classes=$FULL_CLASSES" >> "$GITHUB_OUTPUT"
           echo "open_classes=$OPEN_CLASSES" >> "$GITHUB_OUTPUT"
+
+      - name: Manage GitHub opening alerts
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OPEN_CLASSES: ${{ steps.effective_stats.outputs.open_classes }}
+        run: |
+          set -euo pipefail
+
+          ALERT_TITLE="Swim opening available"
+          ALERT_LABEL="swim-opening-alert"
+
+          if [ "$OPEN_CLASSES" -gt 0 ]; then
+            ISSUE_BODY=$(cat <<EOF_ISSUE
+          Openings are currently available for **Swim Colours 5 – Purple (low ratio)**.
+
+          - Classes with openings: ${{ steps.effective_stats.outputs.open_classes }}
+          - Total classes found: ${{ steps.effective_stats.outputs.total_classes }}
+          - Full classes: ${{ steps.effective_stats.outputs.full_classes }}
+          - Workflow run: https://github.com/${REPO}/actions/runs/${{ github.run_id }}
+          EOF_ISSUE
+          )
+
+            OPEN_ALERT_ISSUES=$(gh issue list --repo "$REPO" --label "$ALERT_LABEL" --state open --json number,title -q '.[] | select(.title == "'"$ALERT_TITLE"'") | .number')
+
+            if [ -z "$OPEN_ALERT_ISSUES" ]; then
+              gh issue create \
+                --repo "$REPO" \
+                --title "$ALERT_TITLE" \
+                --body "$ISSUE_BODY" \
+                --assignee "KingBain" \
+                --label "$ALERT_LABEL"
+            else
+              while read -r issue_number; do
+                [ -z "$issue_number" ] && continue
+                gh issue comment "$issue_number" --repo "$REPO" --body "$ISSUE_BODY"
+                gh issue edit "$issue_number" --repo "$REPO" --add-assignee "KingBain"
+              done <<< "$OPEN_ALERT_ISSUES"
+            fi
+          else
+            OPEN_ALERT_ISSUES=$(gh issue list --repo "$REPO" --label "$ALERT_LABEL" --state open --json number -q '.[].number')
+
+            if [ -n "$OPEN_ALERT_ISSUES" ]; then
+              while read -r issue_number; do
+                [ -z "$issue_number" ] && continue
+                gh issue close "$issue_number" --repo "$REPO" --comment "No openings were found in the latest run. Closing this alert issue."
+              done <<< "$OPEN_ALERT_ISSUES"
+            else
+              echo "No open opening-alert issues to close."
+            fi
+          fi
 
       - name: Update README with latest status
         run: |


### PR DESCRIPTION
### Motivation

- Provide an in-repo GitHub notification path so openings for the tracked swim class surface as issues and are assigned to `KingBain`.
- Automatically close stale opening alerts when no openings are found to avoid manual cleanup.

### Description

- Added `issues: write` permission to the workflow in `.github/workflows/notifier.yml` so it can manage issues. 
- Introduced a new `Manage GitHub opening alerts` step (skipped during dry runs) that uses the `gh` CLI with `github.token` to create or update a labeled issue `swim-opening-alert` assigned to `KingBain` when openings are found. 
- The step comments and reassigns existing alert issues when they already exist, and closes all `swim-opening-alert` issues with a closing comment when no openings exist. 
- The logic reads `open_classes`, `total_classes`, and `full_classes` from the workflow outputs to decide whether to create, update, or close issues.

### Testing

- Ran `git diff --check` and committed the change with message `feat(actions): manage opening alert issues for KingBain`, which succeeded. 
- Attempted to parse the workflow YAML with Python/`pyyaml`, but `pyyaml` was not available in this environment (warning only). 
- The workflow file was updated at `.github/workflows/notifier.yml` and the change has been staged and committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3518404c832f9026df191d74eef7)