### PR TITLE
fix: align opening issue management for normal and dry-run flows

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -146,7 +146,6 @@ jobs:
           echo "open_classes=$OPEN_CLASSES" >> "$GITHUB_OUTPUT"
 
       - name: Manage GitHub opening alerts
-        if: inputs.dry_run != true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -169,8 +168,9 @@ jobs:
           )
 
             OPEN_ALERT_ISSUES=$(gh issue list --repo "$REPO" --label "$ALERT_LABEL" --state open --json number,title -q '.[] | select(.title == "'"$ALERT_TITLE"'") | .number')
+            CURRENT_ISSUE=$(echo "$OPEN_ALERT_ISSUES" | sed '/^$/d' | head -n 1)
 
-            if [ -z "$OPEN_ALERT_ISSUES" ]; then
+            if [ -z "$CURRENT_ISSUE" ]; then
               gh issue create \
                 --repo "$REPO" \
                 --title "$ALERT_TITLE" \
@@ -178,11 +178,19 @@ jobs:
                 --assignee "KingBain" \
                 --label "$ALERT_LABEL"
             else
-              while read -r issue_number; do
-                [ -z "$issue_number" ] && continue
-                gh issue comment "$issue_number" --repo "$REPO" --body "$ISSUE_BODY"
-                gh issue edit "$issue_number" --repo "$REPO" --add-assignee "KingBain"
-              done <<< "$OPEN_ALERT_ISSUES"
+              gh issue edit "$CURRENT_ISSUE" \
+                --repo "$REPO" \
+                --title "$ALERT_TITLE" \
+                --body "$ISSUE_BODY" \
+                --add-assignee "KingBain"
+
+              EXTRA_ISSUES=$(echo "$OPEN_ALERT_ISSUES" | sed '/^$/d' | tail -n +2)
+              if [ -n "$EXTRA_ISSUES" ]; then
+                while read -r issue_number; do
+                  [ -z "$issue_number" ] && continue
+                  gh issue close "$issue_number" --repo "$REPO" --comment "Consolidating duplicate opening alerts into #$CURRENT_ISSUE."
+                done <<< "$EXTRA_ISSUES"
+              fi
             fi
           else
             OPEN_ALERT_ISSUES=$(gh issue list --repo "$REPO" --label "$ALERT_LABEL" --state open --json number -q '.[].number')


### PR DESCRIPTION
### Motivation
- Ensure the GitHub issue lifecycle reflects the effective opening counts (real or simulated) so dry runs exercise the same create/update/close logic as normal runs.
- Prevent duplicate open alert issues by updating a single canonical issue and closing extras when openings exist.
- Close all labelled opening-alert issues when no openings exist to keep the issue list clean.

### Description
- Removed the `if: inputs.dry_run != true` guard so the issue-management step runs against the `effective_stats` outputs for both normal and dry-run runs.
- Added detection of a `CURRENT_ISSUE` from the list of open alert issues and create a new issue only when none exists using `gh issue create`.
- When a current issue exists, update it using `gh issue edit` (title/body/assignee) and close any additional open duplicates with `gh issue close`.
- Retained logic to close all open alert issues when no openings are found using `gh issue close` for each open issue.

### Testing
- Parsed the edited workflow with Ruby using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/notifier.yml')"` which returned `YAML parse OK`.
- Attempted YAML parse with Python using `PyYAML` which failed due to missing `PyYAML` in the environment.
- Verified repository state with `git status --short` and committed the change with `git commit`, which succeeded.
- Confirmed the workflow file was updated (`.github/workflows/notifier.yml`) and the diff contains the intended additions and deletions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3a4fc784832f9f1060722e9df0af)