### PR TITLE
Detect openings by enrollment action link and include enroll URL in notifications

### DIFF
--- a/.github/workflows/notifier.yml
+++ b/.github/workflows/notifier.yml
@@ -99,7 +99,7 @@ jobs:
 
           # 2. Calculate statistics strictly and safely
           TOTAL_CLASSES=$(jq -r '.body.activity_items // [] | length' api_response.json)
-          OPEN_CLASSES=$(jq -r '[.body.activity_items // [] | .[] | select((.total_open // 0) > (.already_enrolled // 0))] | length' api_response.json)
+          OPEN_CLASSES=$(jq -r '[.body.activity_items // [] | .[] | select((.action_link.href // "") != "")] | length' api_response.json)
 
           TOTAL_CLASSES=${TOTAL_CLASSES:-0}
           OPEN_CLASSES=${OPEN_CLASSES:-0}
@@ -283,20 +283,18 @@ jobs:
       - name: Parse and send messages for available activities
         if: steps.parse_response.outputs.open_classes > 0
         run: |
-          # Loop strictly through items where capacity > enrolled
-          jq -c '.body.activity_items // [] | .[] | select((.total_open // 0) > (.already_enrolled // 0))' api_response.json | while read -r i; do
+          # Loop strictly through items that expose an enrollment action link
+          jq -c '.body.activity_items // [] | .[] | select((.action_link.href // "") != "")' api_response.json | while read -r i; do
             NAME=$(echo "$i" | jq -r '.name')
             DOW=$(echo "$i" | jq -r '.days_of_week')
             DATES=$(echo "$i" | jq -r '.date_range')
             TIME=$(echo "$i" | jq -r '.time_range')
             DETAIL_URL=$(echo "$i" | jq -r '.detail_url')
-
-            # Calculate exactly how many spots are left
-            SPOTS_LEFT=$(echo "$i" | jq -r '(.total_open // 0) - (.already_enrolled // 0)')
+            ENROLL_URL=$(echo "$i" | jq -r '.action_link.href // empty')
 
             # Message formatted for WhatsApp readability
-            MESSAGE=$(printf "🚨 *OPENING FOUND!*\n*Class:* %s\n*Days:* %s\n*Dates:* %s\n*Time:* %s\n*Spots Available:* %s\n*Link:* %s" \
-              "$NAME" "$DOW" "$DATES" "$TIME" "$SPOTS_LEFT" "$DETAIL_URL")
+            MESSAGE=$(printf "🚨 *OPENING FOUND!*\n*Class:* %s\n*Days:* %s\n*Dates:* %s\n*Time:* %s\n*Details:* %s\n*Enroll:* %s" \
+              "$NAME" "$DOW" "$DATES" "$TIME" "$DETAIL_URL" "$ENROLL_URL")
 
             echo -e "Sending opening alert:\n$MESSAGE\n---"
 


### PR DESCRIPTION
### Motivation

- Replace capacity-based heuristics with detection of actionable enrollment links to avoid false positives when capacity fields are unreliable.
- Provide a direct enrollment URL in notifications so recipients can quickly act on openings.

### Description

- Change the `jq` selector for `OPEN_CLASSES` to count items where `action_link.href` is present instead of comparing `total_open` and `already_enrolled` values. 
- Update the loop that enumerates available activities to select items with `action_link.href` and extract `ENROLL_URL` from `.action_link.href` instead of computing `SPOTS_LEFT`.
- Adjust the WhatsApp message format to include a `Details` link and an `Enroll` link instead of a `Spots Available` field.
- Kept artifact upload and overall response parsing and stats output intact while updating output variables used by downstream steps.

### Testing

- Executed the modified GitHub Actions workflow against a sample `api_response.json` in CI and confirmed the parsing step succeeded and items with `action_link.href` were identified. 
- Verified the notification step produced messages containing the `Enroll` URL and completed without errors in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e2f6c14c832f8cbc0d1fb592bfb6)